### PR TITLE
fix(introduction): stop line overlap

### DIFF
--- a/src/app/views/home-page/home-page.component.less
+++ b/src/app/views/home-page/home-page.component.less
@@ -76,6 +76,7 @@
     .text-container {
       text-align: center;
       font-size: 36px;
+      line-height: calc(20 / 14);
       margin: 0 10px 0 10px;
 
       @media screen and (max-width: @mobile-max-width) {


### PR DESCRIPTION
Uses a relative line height to ensure lines don't overlap if font size changes. I used `20 / 14` because it matches the line-height:font-size ratio given by the `@angular/material` framework.

Also is this the correct branch? It's unclear from the histories, none seem to be the clear "main" branch. This one appears to be the one deployed to GH pages though?